### PR TITLE
Category Deletion State Management Issues

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -24,7 +24,7 @@ app.use(cors({
       callback(new Error('Not allowed by CORS'));
     }
   },
-  credentials: true, // Enable credentials if necessary (for cookies, auth)
+  credentials: true,
 }));
 app.use('/api/questions', questionsRoutes);
 app.use('/api/categories', categoriesRoutes);

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -24,7 +24,7 @@ app.use(cors({
       callback(new Error('Not allowed by CORS'));
     }
   },
-  credentials: true,
+  credentials: true, // Enable credentials if necessary (for cookies, auth)
 }));
 app.use('/api/questions', questionsRoutes);
 app.use('/api/categories', categoriesRoutes);

--- a/backend/controllers/questionsController.ts
+++ b/backend/controllers/questionsController.ts
@@ -8,7 +8,7 @@ export async function getAllQuestions(
     next: NextFunction
 ) {
     try {
-        const questions = await questionModel.find().populate("categories"); // Populate categories
+        const questions = await questionModel.find().populate("categories");
         response.status(200).json(questions);
     } catch (error) {
         next(error);
@@ -30,7 +30,6 @@ export async function createQuestion(
             });
         }
 
-        // Find or create categories based on names
         const categoryIds = await Promise.all(
             categories.map(async (categoryName: string) => {
                 let category = await categoryModel.findOne({
@@ -56,7 +55,7 @@ export async function createQuestion(
             difficulty,
             categories: categoryIds,
         });
-        if (url) newQuestion.url = url; // Add url only if it's provided
+        if (url) newQuestion.url = url;
 
         await newQuestion.save();
 
@@ -80,7 +79,6 @@ export async function updateQuestion(
     let { categories, ...updateData } = request.body;
 
     try {
-        // Check for uniqueness of title if updating title
         if (updateData.title) {
             const existingTitle = await questionModel.findOne({ title: updateData.title, _id: { $ne: id } });
             if (existingTitle) {
@@ -91,7 +89,6 @@ export async function updateQuestion(
         }
 
         if (categories) {
-            // If categories are being updated, map names to ObjectId references
             const categoryIds = await Promise.all(
                 categories.map(async (categoryName: string) => {
                     let category = await categoryModel.findOne({
@@ -104,16 +101,16 @@ export async function updateQuestion(
                     return category._id;
                 })
             );
-            updateData = { ...updateData, categories: categoryIds }; // Update categories with ObjectId references
+            updateData = { ...updateData, categories: categoryIds };
         }
 
         const updatedQuestion = await questionModel
             .findOneAndUpdate(
                 { _id: id },
                 { $set: updateData },
-                { new: true, runValidators: true } // return the updated document and apply validation
+                { new: true, runValidators: true }
             )
-            .populate("categories"); // Populate categories in the response
+            .populate("categories");
 
         if (!updatedQuestion) {
             return response.status(404).json({

--- a/backend/controllers/questionsController.ts
+++ b/backend/controllers/questionsController.ts
@@ -8,7 +8,7 @@ export async function getAllQuestions(
     next: NextFunction
 ) {
     try {
-        const questions = await questionModel.find().populate("categories");
+        const questions = await questionModel.find().populate("categories"); // Populate categories
         response.status(200).json(questions);
     } catch (error) {
         next(error);
@@ -30,6 +30,7 @@ export async function createQuestion(
             });
         }
 
+        // Find or create categories based on names
         const categoryIds = await Promise.all(
             categories.map(async (categoryName: string) => {
                 let category = await categoryModel.findOne({
@@ -55,7 +56,7 @@ export async function createQuestion(
             difficulty,
             categories: categoryIds,
         });
-        if (url) newQuestion.url = url;
+        if (url) newQuestion.url = url; // Add url only if it's provided
 
         await newQuestion.save();
 
@@ -79,6 +80,7 @@ export async function updateQuestion(
     let { categories, ...updateData } = request.body;
 
     try {
+        // Check for uniqueness of title if updating title
         if (updateData.title) {
             const existingTitle = await questionModel.findOne({ title: updateData.title, _id: { $ne: id } });
             if (existingTitle) {
@@ -89,6 +91,7 @@ export async function updateQuestion(
         }
 
         if (categories) {
+            // If categories are being updated, map names to ObjectId references
             const categoryIds = await Promise.all(
                 categories.map(async (categoryName: string) => {
                     let category = await categoryModel.findOne({
@@ -101,16 +104,16 @@ export async function updateQuestion(
                     return category._id;
                 })
             );
-            updateData = { ...updateData, categories: categoryIds };
+            updateData = { ...updateData, categories: categoryIds }; // Update categories with ObjectId references
         }
 
         const updatedQuestion = await questionModel
             .findOneAndUpdate(
                 { _id: id },
                 { $set: updateData },
-                { new: true, runValidators: true }
+                { new: true, runValidators: true } // return the updated document and apply validation
             )
-            .populate("categories");
+            .populate("categories"); // Populate categories in the response
 
         if (!updatedQuestion) {
             return response.status(404).json({

--- a/backend/data/questions.json
+++ b/backend/data/questions.json
@@ -8,7 +8,7 @@
     },
     {
         "title": "Linked List Cycle Detection",
-        "description": "Implement a function to detect if a linked list contains a cycle.\n\n![Linked List Example](https://assets.leetcode.com/uploads/2018/12/07/circularlinkedlist.png)",
+        "description": "### Problem\n\nImplement a function to detect if a linked list contains a cycle.\n\n![Linked List Cycle](https://assets.leetcode.com/uploads/2018/12/07/circularlinkedlist.png)\n\n### Instructions\n\n- Given a linked list, determine if it has a cycle in it.\n- Can you solve it using O(1) memory?\n\n### Example\n\n**Input:**\n```\nhead = [3, 2, 0, -4], pos = 1 (indicating tail connects to node index 1)\n```\n\n**Output:**\n```\ntrue\n```\n\n### Constraints\n\n- The number of nodes in the list is in the range [0, 10^4].\n- `-10^5 <= Node.val <= 10^5`.",
         "difficulty": "Easy",
         "categories": ["Data Structures", "Algorithms"],
         "url": "https://leetcode.com/problems/linked-list-cycle/"

--- a/backend/models/Category.ts
+++ b/backend/models/Category.ts
@@ -1,7 +1,5 @@
-// CategoryModel.ts
-
 import mongoose, { Schema, Types, Document } from 'mongoose';
-import { Category as SharedCategory } from '@shared/types/Category';  // Import your shared type
+import { Category as SharedCategory } from '@shared/types/Category';
 
 export interface Category
   extends Omit<SharedCategory, '_id'>,
@@ -9,12 +7,10 @@ export interface Category
   _id: Types.ObjectId;
 }
 
-// Create the schema for the Category model
 const categorySchema: Schema<Category> = new Schema<Category>({
   name: { type: String, required: true, unique: true },
 });
 
-// Create the Category model
 const categoryModel = mongoose.model<Category>(
   'category',
   categorySchema

--- a/backend/models/Category.ts
+++ b/backend/models/Category.ts
@@ -1,5 +1,7 @@
+// CategoryModel.ts
+
 import mongoose, { Schema, Types, Document } from 'mongoose';
-import { Category as SharedCategory } from '@shared/types/Category';
+import { Category as SharedCategory } from '@shared/types/Category';  // Import your shared type
 
 export interface Category
   extends Omit<SharedCategory, '_id'>,
@@ -7,10 +9,12 @@ export interface Category
   _id: Types.ObjectId;
 }
 
+// Create the schema for the Category model
 const categorySchema: Schema<Category> = new Schema<Category>({
   name: { type: String, required: true, unique: true },
 });
 
+// Create the Category model
 const categoryModel = mongoose.model<Category>(
   'category',
   categorySchema

--- a/backend/models/Question.ts
+++ b/backend/models/Question.ts
@@ -1,3 +1,4 @@
+// Question.ts (Backend Model)
 import mongoose, { Schema, Types } from 'mongoose';
 
 export interface Question extends mongoose.Document {
@@ -6,7 +7,7 @@ export interface Question extends mongoose.Document {
   title: string;
   description: string;
   difficulty: string;
-  categories: Types.ObjectId[];
+  categories: Types.ObjectId[]; // Reference ObjectId from Category
   url?: string;
 }
 

--- a/backend/models/Question.ts
+++ b/backend/models/Question.ts
@@ -1,4 +1,3 @@
-// Question.ts (Backend Model)
 import mongoose, { Schema, Types } from 'mongoose';
 
 export interface Question extends mongoose.Document {
@@ -7,7 +6,7 @@ export interface Question extends mongoose.Document {
   title: string;
   description: string;
   difficulty: string;
-  categories: Types.ObjectId[]; // Reference ObjectId from Category
+  categories: Types.ObjectId[];
   url?: string;
 }
 

--- a/frontend/src/data/repositories/mockCategoryRepository.ts
+++ b/frontend/src/data/repositories/mockCategoryRepository.ts
@@ -60,8 +60,8 @@ export class MockCategoryRemoteDataSource {
             setTimeout(() => {
                 const index = this.categories.findIndex(category => category._id === _id);
                 if (index !== -1) {
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     const deletedCategory = this.categories.splice(index, 1)[0];
+                    console.log(`Category "${deletedCategory.name}" deleted. Current categories:`, this.categories); // TODO: Remove when submitting
                     resolve();
                 } else {
                     console.error(`Category with _id "${_id}" not found.`);

--- a/frontend/src/data/repositories/mockCategoryRepository.ts
+++ b/frontend/src/data/repositories/mockCategoryRepository.ts
@@ -60,8 +60,8 @@ export class MockCategoryRemoteDataSource {
             setTimeout(() => {
                 const index = this.categories.findIndex(category => category._id === _id);
                 if (index !== -1) {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     const deletedCategory = this.categories.splice(index, 1)[0];
-                    console.log(`Category "${deletedCategory.name}" deleted. Current categories:`, this.categories); // TODO: Remove when submitting
                     resolve();
                 } else {
                     console.error(`Category with _id "${_id}" not found.`);

--- a/frontend/src/data/repositories/mockCategoryRepository.ts
+++ b/frontend/src/data/repositories/mockCategoryRepository.ts
@@ -43,7 +43,6 @@ export class MockCategoryRemoteDataSource {
                         name: categoryName
                     };
                     this.categories.push(newCategory);
-                    console.log(`Category "${categoryName}" added. Current categories:`, this.categories); 
                     resolve(newCategory);
                 }
             }, 300);

--- a/frontend/src/data/repositories/mockQuestionRepository.ts
+++ b/frontend/src/data/repositories/mockQuestionRepository.ts
@@ -346,6 +346,7 @@ export class MockQuestionRemoteDataSource {
     async createQuestion(question: IQuestionInput): Promise<{ status: number; data: any }> {
         return new Promise(async (resolve, reject) => {
             try {
+                // Resolve categories or create new ones if they don't exist
                 const resolvedCategories = await Promise.all(
                     question.categories.map(async (catName) => {
                         let foundCategory = categories.find((cat) => cat.name === catName);
@@ -357,10 +358,11 @@ export class MockQuestionRemoteDataSource {
                     })
                 );
 
+                // Create the new question object
                 const questionId = (this.questions.length + 1).toString();
                 const newQuestion: Question = {
                     ...question,
-                    categories: resolvedCategories,
+                    categories: resolvedCategories, // Reference full category objects (_id, name)
                     _id: "i" + questionId,
                     code: questionId
                 };
@@ -393,6 +395,7 @@ export class MockQuestionRemoteDataSource {
                     let updatedCategories = this.questions[index].categories;
 
                     if (questionUpdate.categories) {
+                        // Resolve or create categories if needed
                         updatedCategories = await Promise.all(
                             questionUpdate.categories.map(async (catName) => {
                                 let foundCategory = categories.find((cat) => cat.name === catName);
@@ -408,7 +411,7 @@ export class MockQuestionRemoteDataSource {
                     const updatedQuestion = {
                         ...this.questions[index],
                         ...questionUpdate,
-                        categories: updatedCategories
+                        categories: updatedCategories // Use updated categories if provided
                     };
                     this.questions[index] = updatedQuestion;
                     resolve({ status: 200, data: { message: "Updated question", updatedQuestion } });

--- a/frontend/src/data/repositories/mockQuestionRepository.ts
+++ b/frontend/src/data/repositories/mockQuestionRepository.ts
@@ -350,7 +350,6 @@ export class MockQuestionRemoteDataSource {
                     question.categories.map(async (catName) => {
                         let foundCategory = categories.find((cat) => cat.name === catName);
                         if (!foundCategory) {
-                            console.log(`Category "${catName}" not found, creating new category.`);
                             foundCategory = await mockCategoryRemoteDataSource.createCategory(catName);
                         }
                         return foundCategory;
@@ -397,7 +396,6 @@ export class MockQuestionRemoteDataSource {
                             questionUpdate.categories.map(async (catName) => {
                                 let foundCategory = categories.find((cat) => cat.name === catName);
                                 if (!foundCategory) {
-                                    console.log(`Category "${catName}" not found, creating new category.`);
                                     foundCategory = await mockCategoryRemoteDataSource.createCategory(catName);
                                 }
                                 return foundCategory;

--- a/frontend/src/data/repositories/mockQuestionRepository.ts
+++ b/frontend/src/data/repositories/mockQuestionRepository.ts
@@ -346,7 +346,6 @@ export class MockQuestionRemoteDataSource {
     async createQuestion(question: IQuestionInput): Promise<{ status: number; data: any }> {
         return new Promise(async (resolve, reject) => {
             try {
-                // Resolve categories or create new ones if they don't exist
                 const resolvedCategories = await Promise.all(
                     question.categories.map(async (catName) => {
                         let foundCategory = categories.find((cat) => cat.name === catName);
@@ -358,11 +357,10 @@ export class MockQuestionRemoteDataSource {
                     })
                 );
 
-                // Create the new question object
                 const questionId = (this.questions.length + 1).toString();
                 const newQuestion: Question = {
                     ...question,
-                    categories: resolvedCategories, // Reference full category objects (_id, name)
+                    categories: resolvedCategories,
                     _id: "i" + questionId,
                     code: questionId
                 };
@@ -395,7 +393,6 @@ export class MockQuestionRemoteDataSource {
                     let updatedCategories = this.questions[index].categories;
 
                     if (questionUpdate.categories) {
-                        // Resolve or create categories if needed
                         updatedCategories = await Promise.all(
                             questionUpdate.categories.map(async (catName) => {
                                 let foundCategory = categories.find((cat) => cat.name === catName);
@@ -411,7 +408,7 @@ export class MockQuestionRemoteDataSource {
                     const updatedQuestion = {
                         ...this.questions[index],
                         ...questionUpdate,
-                        categories: updatedCategories // Use updated categories if provided
+                        categories: updatedCategories
                     };
                     this.questions[index] = updatedQuestion;
                     resolve({ status: 200, data: { message: "Updated question", updatedQuestion } });

--- a/frontend/src/domain/usecases/QuestionUseCases.ts
+++ b/frontend/src/domain/usecases/QuestionUseCases.ts
@@ -117,10 +117,8 @@ export class QuestionUseCases {
         };
 
         allQuestions.forEach((question) => {
-            // Count by difficulty
             stats.byDifficulty[question.difficulty] = (stats.byDifficulty[question.difficulty] || 0) + 1;
 
-            // Count by category
             question.categories.forEach((category) => {
                 const categoryName = category.name;
                 stats.byCategory[categoryName] = (stats.byCategory[categoryName] || 0) + 1;

--- a/frontend/src/domain/usecases/QuestionUseCases.ts
+++ b/frontend/src/domain/usecases/QuestionUseCases.ts
@@ -117,8 +117,10 @@ export class QuestionUseCases {
         };
 
         allQuestions.forEach((question) => {
+            // Count by difficulty
             stats.byDifficulty[question.difficulty] = (stats.byDifficulty[question.difficulty] || 0) + 1;
 
+            // Count by category
             question.categories.forEach((category) => {
                 const categoryName = category.name;
                 stats.byCategory[categoryName] = (stats.byCategory[categoryName] || 0) + 1;

--- a/frontend/src/presentation/components/Category/CategoryFilter.module.css
+++ b/frontend/src/presentation/components/Category/CategoryFilter.module.css
@@ -1,5 +1,3 @@
-/* CategoryFilter.module.css */
-
 .categoryDropdownContainer {
     padding: 16px;
     box-shadow: none;
@@ -23,35 +21,33 @@
 .checkableTag {
     display: flex;
     align-items: center;
-    padding: 4px 8px; /* Adjusted padding for thinner vertical appearance */
+    padding: 4px 8px;
     cursor: pointer;
-    /* Removed borders and added minimal styling */
     border: none;
     border-radius: 4px;
-    background-color: #ffffff; /* Light gray background for default state */
-    color: rgba(0, 0, 0, 0.85); /* Default text color */
-    transition: background-color 0.2s, color 0.2s; /* Smooth transitions */
-    font-size: 14px; /* Maintain readable font size */
-    height: 24px; /* Reduced height for thinner appearance */
-    line-height: 16px; /* Adjusted line height */
+    background-color: #ffffff;
+    color: rgba(0, 0, 0, 0.85);
+    transition: background-color 0.2s, color 0.2s;
+    font-size: 14px;
+    height: 24px;
+    line-height: 16px;
 }
 
 .checkableTag:hover {
-    background-color: #d9d9d9; /* Slightly darker gray on hover */
+    background-color: #d9d9d9;
 }
 
 .deleteSelectedTag {
-    background-color: #ff4d4f !important; /* Red background */
-    color: #fff !important; /* White text */
-    border: none !important; /* Remove border */
-    /* Ensure the height and padding remain consistent */
+    background-color: #ff4d4f !important;
+    color: #fff !important;
+    border: none !important;
     height: 24px !important;
     padding: 4px 8px !important;
 }
 
 .instructionText {
     margin: 10px 0;
-    color: #ff4d4f; /* Red color */
+    color: #ff4d4f;
     font-weight: bold;
     text-align: center;
 }

--- a/frontend/src/presentation/components/Category/CategoryFilter.module.css
+++ b/frontend/src/presentation/components/Category/CategoryFilter.module.css
@@ -37,6 +37,11 @@
     background-color: #d9d9d9;
 }
 
+.selectedTag {
+    background-color: #1890ff;
+    color: #fff;
+}
+
 .deleteSelectedTag {
     background-color: #ff4d4f !important;
     color: #fff !important;

--- a/frontend/src/presentation/components/Category/CategoryFilter.module.css
+++ b/frontend/src/presentation/components/Category/CategoryFilter.module.css
@@ -1,3 +1,5 @@
+/* CategoryFilter.module.css */
+
 .categoryDropdownContainer {
     padding: 16px;
     box-shadow: none;
@@ -21,33 +23,35 @@
 .checkableTag {
     display: flex;
     align-items: center;
-    padding: 4px 8px;
+    padding: 4px 8px; /* Adjusted padding for thinner vertical appearance */
     cursor: pointer;
+    /* Removed borders and added minimal styling */
     border: none;
     border-radius: 4px;
-    background-color: #ffffff;
-    color: rgba(0, 0, 0, 0.85);
-    transition: background-color 0.2s, color 0.2s;
-    font-size: 14px;
-    height: 24px;
-    line-height: 16px;
+    background-color: #ffffff; /* Light gray background for default state */
+    color: rgba(0, 0, 0, 0.85); /* Default text color */
+    transition: background-color 0.2s, color 0.2s; /* Smooth transitions */
+    font-size: 14px; /* Maintain readable font size */
+    height: 24px; /* Reduced height for thinner appearance */
+    line-height: 16px; /* Adjusted line height */
 }
 
 .checkableTag:hover {
-    background-color: #d9d9d9;
+    background-color: #d9d9d9; /* Slightly darker gray on hover */
 }
 
 .deleteSelectedTag {
-    background-color: #ff4d4f !important;
-    color: #fff !important;
-    border: none !important;
+    background-color: #ff4d4f !important; /* Red background */
+    color: #fff !important; /* White text */
+    border: none !important; /* Remove border */
+    /* Ensure the height and padding remain consistent */
     height: 24px !important;
     padding: 4px 8px !important;
 }
 
 .instructionText {
     margin: 10px 0;
-    color: #ff4d4f;
+    color: #ff4d4f; /* Red color */
     font-weight: bold;
     text-align: center;
 }

--- a/frontend/src/presentation/components/Category/CategoryFilter.tsx
+++ b/frontend/src/presentation/components/Category/CategoryFilter.tsx
@@ -87,8 +87,7 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = ({
                 className={styles.categorySearchBar}
                 allowClear
             />
-
-            {/* Instructional Text for Delete Mode */}
+            
             {deletingMode && <div className={styles.instructionText}>Select categories to delete</div>}
 
             <div className={styles.categoriesGrid}>

--- a/frontend/src/presentation/components/Category/CategoryFilter.tsx
+++ b/frontend/src/presentation/components/Category/CategoryFilter.tsx
@@ -1,3 +1,4 @@
+// CategoryFilter.tsx
 import React, { useState } from "react";
 import { Input, Tag, Button, Modal } from "antd";
 import { PlusOutlined, DeleteOutlined, ExclamationCircleOutlined } from "@ant-design/icons";

--- a/frontend/src/presentation/components/Category/CategoryFilter.tsx
+++ b/frontend/src/presentation/components/Category/CategoryFilter.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
-import { Input, Tag, Button, Modal } from "antd";
-import { PlusOutlined, DeleteOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
-import styles from "./CategoryFilter.module.css";
-import { Category } from "domain/entities/Category";
+import React, { useState } from 'react';
+import { Input, Tag, Button, Modal } from 'antd';
+import { PlusOutlined, DeleteOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
+import styles from './CategoryFilter.module.css';
+import { Category } from 'domain/entities/Category';
 
 const { CheckableTag } = Tag;
 
@@ -87,19 +87,21 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = ({
                 className={styles.categorySearchBar}
                 allowClear
             />
-            
+
             {deletingMode && <div className={styles.instructionText}>Select categories to delete</div>}
 
             <div className={styles.categoriesGrid}>
                 {filteredCategories.map((category) => {
                     const isSelectedForDeletion = deletingMode && categoriesToDelete.includes(category._id);
+                    const isSelectedForFiltering = selectedCategories.includes(category._id);
+
                     return (
                         <CheckableTag
                             key={category._id}
                             checked={
                                 deletingMode
-                                    ? categoriesToDelete.includes(category._id)
-                                    : selectedCategories.includes(category._id)
+                                    ? isSelectedForDeletion
+                                    : isSelectedForFiltering
                             }
                             onChange={(checked) =>
                                 deletingMode
@@ -107,7 +109,11 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = ({
                                     : onCategoryChange(category._id, checked)
                             }
                             className={`${styles.checkableTag} ${
-                                isSelectedForDeletion ? styles.deleteSelectedTag : ""
+                                isSelectedForDeletion
+                                    ? styles.deleteSelectedTag
+                                    : isSelectedForFiltering
+                                    ? styles.selectedTag
+                                    : ""
                             }`}
                         >
                             {category.name}
@@ -158,3 +164,4 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = ({
         </div>
     );
 };
+

--- a/frontend/src/presentation/components/Category/CategoryFilter.tsx
+++ b/frontend/src/presentation/components/Category/CategoryFilter.tsx
@@ -1,4 +1,3 @@
-// CategoryFilter.tsx
 import React, { useState } from "react";
 import { Input, Tag, Button, Modal } from "antd";
 import { PlusOutlined, DeleteOutlined, ExclamationCircleOutlined } from "@ant-design/icons";

--- a/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
+++ b/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
 import React, { useState, useEffect } from "react";
 import { Input, Form, Select, Row, Col, Button, Spin, Alert } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
@@ -32,6 +31,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
 
     const { code: _, categories: questionCategories, ...questionUpdateInput } = question;
 
+    // Transform question categories to an array of their _id values
     const initialCategoryIds = questionCategories.map((cat) => cat._id);
 
     useEffect(() => {
@@ -56,15 +56,17 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
 
     async function handleSubmit(questionUpdate: IQuestionUpdateInput) {
         try {
+            // Get the selected category IDs from the form
             const selectedCategoryIds = form.getFieldValue("categories");
 
+            // Map the selected category IDs back to their names
             const selectedCategoryNames = categories
                 .filter((category) => selectedCategoryIds.includes(category._id))
                 .map((category) => category.name);
 
             const updatedQuestion = {
                 ...questionUpdate,
-                categories: selectedCategoryNames
+                categories: selectedCategoryNames // Send category names instead of _id
             };
 
             const data = await questionUseCases.updateQuestion(question._id, updatedQuestion);
@@ -80,6 +82,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
         }
     }
 
+    // Map categories to Select options
     const categoryOptions = categories.map((category) => ({
         label: category.name,
         value: category._id
@@ -97,7 +100,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
                     onFinish={handleSubmit}
                     initialValues={{
                         ...questionUpdateInput,
-                        categories: initialCategoryIds
+                        categories: initialCategoryIds // Pre-fill categories
                     }}
                     validateMessages={validateMessages}
                     scrollToFirstError

--- a/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
+++ b/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
@@ -32,14 +32,21 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
 
     const { code: _, categories: questionCategories, ...questionUpdateInput } = question;
 
-    const initialCategoryIds = questionCategories.map((cat) => cat._id);
+    const [initialCategoryIds, setInitialCategoryIds] = useState<string[]>([]);
 
     useEffect(() => {
         const fetchCategories = async () => {
             setIsLoadingCategories(true);
             try {
                 const fetchedCategories: Category[] = await categoryUseCases.getAllCategories();
+
+                const validCategoryIds = fetchedCategories.map(cat => cat._id);
+
+                const filteredQuestionCategories = questionCategories
+                    .filter(cat => validCategoryIds.includes(cat._id));
+
                 setCategories(fetchedCategories);
+                setInitialCategoryIds(filteredQuestionCategories.map(cat => cat._id));
             } catch (error) {
                 const message = (error as Error).message || "Failed to fetch categories";
                 setCategoriesError(message);
@@ -50,7 +57,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
             }
         };
         fetchCategories();
-    }, []);
+    }, [questionCategories]);
 
     const { FIELD_TITLE, FIELD_DIFFICULTY, FIELD_DESCRIPTION, FIELD_CATEGORIES, FIELD_URL } = QUESTION_FORM_FIELDS;
 

--- a/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
+++ b/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string */
 import React, { useState, useEffect } from "react";
 import { Input, Form, Select, Row, Col, Button, Spin, Alert } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
@@ -31,7 +32,6 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
 
     const { code: _, categories: questionCategories, ...questionUpdateInput } = question;
 
-    // Transform question categories to an array of their _id values
     const initialCategoryIds = questionCategories.map((cat) => cat._id);
 
     useEffect(() => {
@@ -56,17 +56,15 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
 
     async function handleSubmit(questionUpdate: IQuestionUpdateInput) {
         try {
-            // Get the selected category IDs from the form
             const selectedCategoryIds = form.getFieldValue("categories");
 
-            // Map the selected category IDs back to their names
             const selectedCategoryNames = categories
                 .filter((category) => selectedCategoryIds.includes(category._id))
                 .map((category) => category.name);
 
             const updatedQuestion = {
                 ...questionUpdate,
-                categories: selectedCategoryNames // Send category names instead of _id
+                categories: selectedCategoryNames
             };
 
             const data = await questionUseCases.updateQuestion(question._id, updatedQuestion);
@@ -82,7 +80,6 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
         }
     }
 
-    // Map categories to Select options
     const categoryOptions = categories.map((category) => ({
         label: category.name,
         value: category._id
@@ -100,7 +97,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
                     onFinish={handleSubmit}
                     initialValues={{
                         ...questionUpdateInput,
-                        categories: initialCategoryIds // Pre-fill categories
+                        categories: initialCategoryIds
                     }}
                     validateMessages={validateMessages}
                     scrollToFirstError

--- a/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
+++ b/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string */
 import React, { useState, useEffect } from "react";
 import { Input, Form, Select, Row, Col, Button, Spin, Alert } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
@@ -31,7 +32,6 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
 
     const { code: _, categories: questionCategories, ...questionUpdateInput } = question;
 
-    // Transform question categories to an array of their _id values
     const initialCategoryIds = questionCategories.map((cat) => cat._id);
 
     useEffect(() => {
@@ -55,7 +55,6 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
     const { FIELD_TITLE, FIELD_DIFFICULTY, FIELD_DESCRIPTION, FIELD_CATEGORIES, FIELD_URL } = QUESTION_FORM_FIELDS;
 
     async function handleSubmit(questionUpdate: IQuestionUpdateInput) {
-        // Compare and only get the changed fields. Can shallow compare, for now
         for (const field in questionUpdate) {
             if (questionUpdate[field as keyof IQuestionUpdateInput] === question[field as keyof Question]) {
                 delete questionUpdate[field as keyof IQuestionUpdateInput];
@@ -63,7 +62,6 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
         }
 
         try {
-            // Get the selected category IDs from the form
             const selectedCategoryIds = form.getFieldValue("categories");
             const isCategoriesUpdated =
                 selectedCategoryIds.length !== question.categories.length ||
@@ -71,12 +69,11 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
                     question.categories.some((category) => category._id === cid)
                 );
             if (isCategoriesUpdated) {
-                // Map the selected category IDs back to their names
                 const selectedCategoryNames = categories
                     .filter((category) => selectedCategoryIds.includes(category._id))
                     .map((category) => category.name);
 
-                questionUpdate.categories = selectedCategoryNames; // Send category names instead of _id
+                questionUpdate.categories = selectedCategoryNames;
             } else {
                 delete questionUpdate.categories;
             }
@@ -93,7 +90,6 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
         }
     }
 
-    // Map categories to Select options
     const categoryOptions = categories.map((category) => ({
         label: category.name,
         value: category._id
@@ -111,7 +107,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
                     onFinish={handleSubmit}
                     initialValues={{
                         ...questionUpdateInput,
-                        categories: initialCategoryIds // Pre-fill categories
+                        categories: initialCategoryIds
                     }}
                     validateMessages={validateMessages}
                     scrollToFirstError

--- a/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
+++ b/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
 import React, { useState, useEffect } from "react";
 import { Input, Form, Select, Row, Col, Button } from "antd";
 import styles from "./NewQuestionForm.module.css";
@@ -20,7 +19,7 @@ interface NewQuestionFormProps {
 export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) => {
     const [form] = Form.useForm();
     const [categoryOptions, setCategoryOptions] = useState<{ value: string; label: string }[]>([]);
-    const [categories, setCategories] = useState<Category[]>([]);
+    const [categories, setCategories] = useState<Category[]>([]); // To store the full category objects
     const [loadingCategories, setLoadingCategories] = useState<boolean>(false);
 
     const validateMessages = {
@@ -40,7 +39,7 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
                     label: category.name
                 }));
                 setCategoryOptions(options);
-                setCategories(fetchedCategories);
+                setCategories(fetchedCategories); // Store full categories for later mapping
             } catch (error) {
                 console.error("Failed to fetch categories", error);
                 toast.error("Failed to load categories.");
@@ -54,15 +53,18 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
 
     async function handleSubmit(question: IQuestionInput) {
         try {
+            // Get selected category IDs from the form
             const selectedCategoryIds = form.getFieldValue("categories");
 
+            // Map the selected category IDs back to their names
             const selectedCategoryNames = categories
                 .filter((category) => selectedCategoryIds.includes(category._id))
                 .map((category) => category.name);
 
+            // Prepare the updated question object
             const questionWithDescription = {
                 ...question,
-                categories: selectedCategoryNames
+                categories: selectedCategoryNames // Send category names instead of _id
             };
 
             const data = await questionUseCases.createQuestion(questionWithDescription);

--- a/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
+++ b/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string */
 import React, { useState, useEffect } from "react";
 import { Input, Form, Select, Row, Col, Button } from "antd";
 import styles from "./NewQuestionForm.module.css";
@@ -19,7 +20,7 @@ interface NewQuestionFormProps {
 export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) => {
     const [form] = Form.useForm();
     const [categoryOptions, setCategoryOptions] = useState<{ value: string; label: string }[]>([]);
-    const [categories, setCategories] = useState<Category[]>([]); // To store the full category objects
+    const [categories, setCategories] = useState<Category[]>([]);
     const [loadingCategories, setLoadingCategories] = useState<boolean>(false);
 
     const validateMessages = {
@@ -39,7 +40,7 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
                     label: category.name
                 }));
                 setCategoryOptions(options);
-                setCategories(fetchedCategories); // Store full categories for later mapping
+                setCategories(fetchedCategories);
             } catch (error) {
                 console.error("Failed to fetch categories", error);
                 toast.error("Failed to load categories.");
@@ -53,18 +54,15 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
 
     async function handleSubmit(question: IQuestionInput) {
         try {
-            // Get selected category IDs from the form
             const selectedCategoryIds = form.getFieldValue("categories");
 
-            // Map the selected category IDs back to their names
             const selectedCategoryNames = categories
                 .filter((category) => selectedCategoryIds.includes(category._id))
                 .map((category) => category.name);
 
-            // Prepare the updated question object
             const questionWithDescription = {
                 ...question,
-                categories: selectedCategoryNames // Send category names instead of _id
+                categories: selectedCategoryNames
             };
 
             const data = await questionUseCases.createQuestion(questionWithDescription);

--- a/frontend/src/presentation/components/QuestionDetail.module.css
+++ b/frontend/src/presentation/components/QuestionDetail.module.css
@@ -103,6 +103,7 @@
     font-weight: bold;
 }
 
+/* Styles for working mode */
 .working .card {
     padding: 16px;
 }

--- a/frontend/src/presentation/components/QuestionDetail.module.css
+++ b/frontend/src/presentation/components/QuestionDetail.module.css
@@ -103,7 +103,6 @@
     font-weight: bold;
 }
 
-/* Styles for working mode */
 .working .card {
     padding: 16px;
 }

--- a/frontend/src/presentation/components/QuestionDetail.tsx
+++ b/frontend/src/presentation/components/QuestionDetail.tsx
@@ -28,7 +28,6 @@ export const QuestionDetail: React.FC<QuestionDetailProps> = ({ question, onEdit
     const handleDeleteQuestion = async () => {
         try {
             await questionUseCases.deleteQuestion(question._id);
-            // BE returns _id in message, so use question title for better readability
             toast.success(`Deleted question: ${question.title}`);
             setIsDeleteModalOpen(false);
             onDelete?.(question);

--- a/frontend/src/presentation/components/QuestionDetail.tsx
+++ b/frontend/src/presentation/components/QuestionDetail.tsx
@@ -28,6 +28,7 @@ export const QuestionDetail: React.FC<QuestionDetailProps> = ({ question, onEdit
     const handleDeleteQuestion = async () => {
         try {
             await questionUseCases.deleteQuestion(question._id);
+            // BE returns _id in message, so use question title for better readability
             toast.success(`Deleted question: ${question.title}`);
             setIsDeleteModalOpen(false);
             onDelete?.(question);

--- a/frontend/src/presentation/components/QuestionFilters.tsx
+++ b/frontend/src/presentation/components/QuestionFilters.tsx
@@ -1,3 +1,4 @@
+// QuestionFilters.tsx
 import React, { useState } from "react";
 import { Dropdown, Button, Select } from "antd";
 import { DownOutlined } from "@ant-design/icons";

--- a/frontend/src/presentation/components/QuestionFilters.tsx
+++ b/frontend/src/presentation/components/QuestionFilters.tsx
@@ -1,4 +1,3 @@
-// QuestionFilters.tsx
 import React, { useState } from "react";
 import { Dropdown, Button, Select } from "antd";
 import { DownOutlined } from "@ant-design/icons";

--- a/frontend/src/presentation/components/QuestionList.tsx
+++ b/frontend/src/presentation/components/QuestionList.tsx
@@ -1,3 +1,4 @@
+// QuestionList.tsx
 import React, { useState, useEffect } from "react";
 import { List, Spin, Alert, message } from "antd";
 import { Question } from "../../domain/entities/Question";
@@ -37,6 +38,7 @@ export const QuestionList: React.FC<QuestionListProps> = ({
         const fetchCategories = async () => {
             try {
                 const categories: Category[] = await categoryUseCases.getAllCategories();
+                // Filter out any categories without a valid name or _id
                 const validCategories = categories.filter(
                     (category) => 
                         typeof category.name === 'string' && 
@@ -54,6 +56,7 @@ export const QuestionList: React.FC<QuestionListProps> = ({
         fetchCategories();
     }, []);
 
+    // Handler to add a new category
     const handleAddCategory = async (categoryName: string) => {
         if (!categoryName || categoryName.trim() === "") {
             message.error("Category cannot be empty!");
@@ -73,18 +76,19 @@ export const QuestionList: React.FC<QuestionListProps> = ({
 
         try {
             const response = await categoryUseCases.createCategory(categoryName);
-            const { category } = response;
+            const { category } = response; // Extract the category from the response
 
+            // Ensure that category has valid _id and name
             if (!category || typeof category._id !== 'string' || typeof category.name !== 'string') {
                 message.error("Invalid category data received from backend.");
                 console.error("Invalid category data:", category);
                 return;
             }
 
-            setAllCategories([...allCategories, category]);
+            setAllCategories([...allCategories, category]); // Update the categories state
             setFilters({
                 ...filters,
-                searchTerm: ''
+                searchTerm: '' // Reset search term to show all categories including the new one
             });
 
             message.success("Category added successfully!");
@@ -94,10 +98,11 @@ export const QuestionList: React.FC<QuestionListProps> = ({
         }
     };
 
+    // Handler to delete categories
     const handleDeleteCategory = async (categoriesToDeleteIds: string[]) => {
         try {
             await Promise.all(categoriesToDeleteIds.map((categoryId) => categoryUseCases.deleteCategory(categoryId)));
-            setAllCategories(allCategories.filter((category) => !categoriesToDeleteIds.includes(category._id)));
+            setAllCategories(allCategories.filter((category) => !categoriesToDeleteIds.includes(category._id))); // Update categories
             setFilters({
                 ...filters,
                 selectedCategories: filters.selectedCategories.filter(c => !categoriesToDeleteIds.includes(c))
@@ -159,8 +164,8 @@ export const QuestionList: React.FC<QuestionListProps> = ({
             <QuestionFilters
                 allCategories={allCategories}
                 onFiltersChange={handleFiltersChange}
-                onAddCategory={handleAddCategory}
-                onDeleteCategory={handleDeleteCategory}
+                onAddCategory={handleAddCategory} // Pass handler instead of setAllCategories
+                onDeleteCategory={handleDeleteCategory} // Pass handler instead of setAllCategories
             />
             <div className={styles.listContainer}>
                 {isLoading ? (

--- a/frontend/src/presentation/components/QuestionList.tsx
+++ b/frontend/src/presentation/components/QuestionList.tsx
@@ -1,4 +1,3 @@
-// QuestionList.tsx
 import React, { useState, useEffect } from "react";
 import { List, Spin, Alert, message } from "antd";
 import { Question } from "../../domain/entities/Question";
@@ -38,7 +37,6 @@ export const QuestionList: React.FC<QuestionListProps> = ({
         const fetchCategories = async () => {
             try {
                 const categories: Category[] = await categoryUseCases.getAllCategories();
-                // Filter out any categories without a valid name or _id
                 const validCategories = categories.filter(
                     (category) => 
                         typeof category.name === 'string' && 
@@ -56,7 +54,6 @@ export const QuestionList: React.FC<QuestionListProps> = ({
         fetchCategories();
     }, []);
 
-    // Handler to add a new category
     const handleAddCategory = async (categoryName: string) => {
         if (!categoryName || categoryName.trim() === "") {
             message.error("Category cannot be empty!");
@@ -76,19 +73,18 @@ export const QuestionList: React.FC<QuestionListProps> = ({
 
         try {
             const response = await categoryUseCases.createCategory(categoryName);
-            const { category } = response; // Extract the category from the response
+            const { category } = response;
 
-            // Ensure that category has valid _id and name
             if (!category || typeof category._id !== 'string' || typeof category.name !== 'string') {
                 message.error("Invalid category data received from backend.");
                 console.error("Invalid category data:", category);
                 return;
             }
 
-            setAllCategories([...allCategories, category]); // Update the categories state
+            setAllCategories([...allCategories, category]);
             setFilters({
                 ...filters,
-                searchTerm: '' // Reset search term to show all categories including the new one
+                searchTerm: ''
             });
 
             message.success("Category added successfully!");
@@ -98,11 +94,10 @@ export const QuestionList: React.FC<QuestionListProps> = ({
         }
     };
 
-    // Handler to delete categories
     const handleDeleteCategory = async (categoriesToDeleteIds: string[]) => {
         try {
             await Promise.all(categoriesToDeleteIds.map((categoryId) => categoryUseCases.deleteCategory(categoryId)));
-            setAllCategories(allCategories.filter((category) => !categoriesToDeleteIds.includes(category._id))); // Update categories
+            setAllCategories(allCategories.filter((category) => !categoriesToDeleteIds.includes(category._id)));
             setFilters({
                 ...filters,
                 selectedCategories: filters.selectedCategories.filter(c => !categoriesToDeleteIds.includes(c))
@@ -164,8 +159,8 @@ export const QuestionList: React.FC<QuestionListProps> = ({
             <QuestionFilters
                 allCategories={allCategories}
                 onFiltersChange={handleFiltersChange}
-                onAddCategory={handleAddCategory} // Pass handler instead of setAllCategories
-                onDeleteCategory={handleDeleteCategory} // Pass handler instead of setAllCategories
+                onAddCategory={handleAddCategory}
+                onDeleteCategory={handleDeleteCategory}
             />
             <div className={styles.listContainer}>
                 {isLoading ? (

--- a/frontend/src/presentation/pages/QuestionsPage.tsx
+++ b/frontend/src/presentation/pages/QuestionsPage.tsx
@@ -75,6 +75,10 @@ const QuestionsPage: React.FC = () => {
         setSearchParams({});
     };
 
+    const handleQuestionsUpdated = (updatedQuestions: Question[]) => {
+        setQuestions(updatedQuestions);
+    };
+
     const renderBreadcrumb = () => {
         const breadcrumbItems = [
             {
@@ -110,12 +114,13 @@ const QuestionsPage: React.FC = () => {
                 <Row className={styles.contentRow} gutter={32}>
                     <Col span={8} className={styles.transitionCol}>
                         <QuestionList
-                            isNarrow={selectedQuestion !== null}
+                            isNarrow={selectedQuestion !== undefined}
                             questions={questions}
                             selectedQuestion={selectedQuestion}
                             onSelectQuestion={handleSelectQuestion}
                             isLoading={isLoading}
                             error={error}
+                            onQuestionsUpdated={handleQuestionsUpdated}
                         />
                         <div className={styles.addButtonWrapper}>
                             <AddQuestionButton label={QUESTIONS_PAGE_TEXT.ADD_QUESTION} onClick={handleAddQuestion} />

--- a/frontend/src/presentation/pages/QuestionsPage.tsx
+++ b/frontend/src/presentation/pages/QuestionsPage.tsx
@@ -22,6 +22,8 @@ const QuestionsPage: React.FC = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const selectedQuestionCode = searchParams.get("code");
 
+    // Search params are strings whereas question coodes are numbers, so need to convert to string
+    // No need to store selectedQuestion as state because changing search params will cause the page to re-render
     const selectedQuestion: Question | undefined = questions.find((q) => q.code.toString() === selectedQuestionCode);
 
     useEffect(() => {

--- a/frontend/src/presentation/pages/QuestionsPage.tsx
+++ b/frontend/src/presentation/pages/QuestionsPage.tsx
@@ -22,8 +22,6 @@ const QuestionsPage: React.FC = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const selectedQuestionCode = searchParams.get("code");
 
-    // Search params are strings whereas question coodes are numbers, so need to convert to string
-    // No need to store selectedQuestion as state because changing search params will cause the page to re-render
     const selectedQuestion: Question | undefined = questions.find((q) => q.code.toString() === selectedQuestionCode);
 
     useEffect(() => {


### PR DESCRIPTION
Fixed a bug where deleting categories still leaves phantom category data in EditQuestionForm.tsx and QuestionDetails.tsx. Specifically, if you delete a category that question X possesses, then edit it, the deleted question's _id then becomes visible in the categories of the edit form. And for question detail, the old category's name is just still there.

Additionally, removed unnecessary comments and console.logs everywhere that I can see.

Finally, also added more details into linked list data description in the background.