### PR TITLE
Fix form warning

### DIFF
--- a/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
+++ b/frontend/src/presentation/components/EditQuestionForm/EditQuestionForm.tsx
@@ -24,6 +24,7 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
     const [categories, setCategories] = useState<Category[]>([]);
     const [isLoadingCategories, setIsLoadingCategories] = useState<boolean>(false);
     const [categoriesError, setCategoriesError] = useState<string | null>(null);
+    const [description, setDescription] = useState<string>(question.description)
 
     const validateMessages = {
         required: "${label} is required",
@@ -180,10 +181,8 @@ export const EditQuestionForm: React.FC<EditQuestionFormProps> = ({ question, on
                                 rules={[{ required: true, whitespace: true }]}
                             >
                                 <ReactMarkdown
-                                    value={form.getFieldValue(FIELD_DESCRIPTION.name) || ""}
-                                    onChange={(description) =>
-                                        form.setFieldValue(FIELD_DESCRIPTION.name, description || "")
-                                    }
+                                    value={description}
+                                    onChange={(description) => setDescription(description || "")}
                                 />
                             </Form.Item>
                         </Col>

--- a/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
+++ b/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
@@ -22,6 +22,7 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
     const [categoryOptions, setCategoryOptions] = useState<{ value: string; label: string }[]>([]);
     const [categories, setCategories] = useState<Category[]>([]);
     const [loadingCategories, setLoadingCategories] = useState<boolean>(false);
+    const [description, setDescription] = useState<string>(initialQuestionInput?.description)
 
     const validateMessages = {
         required: "${label} is required",
@@ -51,6 +52,10 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
 
         fetchCategories();
     }, []);
+
+    useEffect(() => {
+        form.setFieldValue(FIELD_DESCRIPTION, description)
+    }, [description])
 
     async function handleSubmit(question: IQuestionInput) {
         try {
@@ -141,10 +146,8 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
                             rules={[{ required: true, whitespace: true }]}
                         >
                             <ReactMarkdown
-                                value={form.getFieldValue(FIELD_DESCRIPTION.name) || ""}
-                                onChange={(description) =>
-                                    form.setFieldValue(FIELD_DESCRIPTION.name, description || "")
-                                }
+                                value={description}
+                                onChange={(description) => setDescription(description || "")}
                             />
                         </Form.Item>
                     </Col>

--- a/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
+++ b/frontend/src/presentation/components/NewQuestionForm/NewQuestionForm.tsx
@@ -53,10 +53,6 @@ export const NewQuestionForm: React.FC<NewQuestionFormProps> = ({ onSubmit }) =>
         fetchCategories();
     }, []);
 
-    useEffect(() => {
-        form.setFieldValue(FIELD_DESCRIPTION, description)
-    }, [description])
-
     async function handleSubmit(question: IQuestionInput) {
         try {
             const selectedCategoryIds = form.getFieldValue("categories");


### PR DESCRIPTION
Looks like the problem is caused by calling `form.getFieldValue` before the `Form` component actually registers the `form`
https://stackoverflow.com/a/61057608

The `description` state is only used to update the markdown display. Its value is not used for form submission since it's already captured in `form` (uncontrolled)